### PR TITLE
 Replace missing pip function with pkg_resources.working_set

### DIFF
--- a/aiohttp_healthcheck/__init__.py
+++ b/aiohttp_healthcheck/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-import imp
 import json
 import os
 import logging
@@ -188,9 +187,12 @@ class EnvironmentDump(object):
                                    'micro': sys.version_info.micro,
                                    'releaselevel': sys.version_info.releaselevel,
                                    'serial': sys.version_info.serial}}
-        if imp.find_module('pip'):
-            import pip
-            packages = dict([(p.project_name, p.version) for p in pip.get_installed_distributions()])
+        try:
+            import pkg_resources
+        except ImportError:
+            pass
+        else:
+            packages = {p.project_name: p.version for p in pkg_resources.working_set}
             result['packages'] = packages
 
         return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==1.1.1
-pylint==1.2.1
-pep8==1.5.7
-six==1.10.0
+aiohttp==3.4.4
+pylint==2.1.1
+pep8==1.7.1
+six==1.11.0

--- a/tests/test_unit/test_healthcheck.py
+++ b/tests/test_unit/test_healthcheck.py
@@ -12,8 +12,8 @@ class BasicHealthCheckTest(AioHTTPTestCase):
         self.hc = HealthCheck()
         super().setUp()
 
-    def get_app(self, loop):
-        app = web.Application(loop=loop)
+    async def get_application(self):
+        app = web.Application()
         app.router.add_get(self.path, self.hc)
         return app
 
@@ -48,8 +48,8 @@ class BasicEnvironmentDumpTest(AioHTTPTestCase):
         self.hc = EnvironmentDump()
         super().setUp()
 
-    def get_app(self, loop):
-        app = web.Application(loop=loop)
+    async def get_application(self):
+        app = web.Application()
         app.router.add_get(self.path, self.hc)
         return app
 

--- a/tests/test_unit/test_healthcheck.py
+++ b/tests/test_unit/test_healthcheck.py
@@ -14,7 +14,7 @@ class BasicHealthCheckTest(AioHTTPTestCase):
 
     async def get_application(self):
         app = web.Application()
-        app.router.add_get(self.path, self.hc)
+        app.router.add_get(self.path, self.hc.__call__)
         return app
 
     @unittest_run_loop
@@ -50,7 +50,7 @@ class BasicEnvironmentDumpTest(AioHTTPTestCase):
 
     async def get_application(self):
         app = web.Application()
-        app.router.add_get(self.path, self.hc)
+        app.router.add_get(self.path, self.hc.__call__)
         return app
 
     @unittest_run_loop


### PR DESCRIPTION
pip.get_installed_distributions() was removed from pip v10.0.
Instead we can use pkg_resources.working_set, from setuptools.

I also upgraded dependencies to latest versions, and fixed failing tests from old versions.

Only tested on python3.7, but should work everywhere.