### PR TITLE
Upgrade from circleci v1 to v2, as v1 is obsolete.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3
+    steps:
+      - checkout
+      - run: pip install -r requirements.txt
+      - run: python setup.py test
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,0 @@
----
-machine:
-  python:
-    version: 3.5.1
-


### PR DESCRIPTION
Signed-off-by: Even Thomassen <even.thomassen@noriginmedia.com>