### PR TITLE
CircleCI pip install as user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,6 @@ jobs:
       - image: circleci/python:3
     steps:
       - checkout
-      - run: pip install -r requirements.txt
+      - run: pip install --user -r requirements.txt
       - run: python setup.py test
 


### PR DESCRIPTION
Pip installation of dependencies on CircleCI doesn't work because no access to the system install folder.
Using --user seems to be the preferred way of solving it.

Sorry for the mistake of not including it in the previous request.